### PR TITLE
Fix icon names in HomePage

### DIFF
--- a/apps/mobile/src/screens/HomePage/HomePage.js
+++ b/apps/mobile/src/screens/HomePage/HomePage.js
@@ -17,12 +17,12 @@ const serviciosRecurrentes = [
   {
     id: '1',
     label: 'Pregunta por un fontanero',
-    icon: 'handyman-outline',
+    icon: 'hammer-outline',
   },
   {
     id: '2',
     label: 'Pregunta por un mecánico',
-    icon: 'wrench-outline',
+    icon: 'car-sport-outline',
   },
   {
     id: '3',


### PR DESCRIPTION
## Summary
- fix invalid Ionicons names in HomePage screen

## Testing
- `node -c apps/mobile/src/screens/HomePage/HomePage.js`
- `npm start` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_683f5556a4388326b50f40e0ead2c44d