### PR TITLE
Implement new minimal settings screen

### DIFF
--- a/apps/mobile/src/navigation/index.js
+++ b/apps/mobile/src/navigation/index.js
@@ -61,7 +61,6 @@ export default function AppNavigator() {
         <Stack.Screen name="Notifications" component={NotificationsScreen} />
         <Stack.Screen name="Payment" component={PaymentScreen} />
         <Stack.Screen name="HelpSupport" component={HelpSupportScreen} />
-              
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/apps/mobile/src/navigation/index.js
+++ b/apps/mobile/src/navigation/index.js
@@ -15,6 +15,9 @@ import MyRequestsScreen from '../screens/MyRequests/MyRequestsScreen';
 import Footer from '../components/Footer/Footer';
 import ProfileScreen from '../screens/Profile/ProfileScreen';
 import SettingsScreen from '../screens/Settings/SettingsScreen';
+import NotificationsScreen from '../screens/Notifications/NotificationsScreen';
+import PaymentScreen from '../screens/Payment/PaymentScreen';
+import HelpSupportScreen from '../screens/HelpSupport/HelpSupportScreen';
 
 const Stack = createNativeStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -55,6 +58,9 @@ export default function AppNavigator() {
           })}
         />
         <Stack.Screen name="Chat" component={ChatScreen} />
+        <Stack.Screen name="Notifications" component={NotificationsScreen} />
+        <Stack.Screen name="Payment" component={PaymentScreen} />
+        <Stack.Screen name="HelpSupport" component={HelpSupportScreen} />
               
       </Stack.Navigator>
     </NavigationContainer>

--- a/apps/mobile/src/screens/HelpSupport/HelpSupportScreen.js
+++ b/apps/mobile/src/screens/HelpSupport/HelpSupportScreen.js
@@ -1,11 +1,28 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
 import styles from './HelpSupportScreen.styles';
 
 export default function HelpSupportScreen() {
+  const navigation = useNavigation();
+
   return (
     <SafeAreaView style={styles.container}>
+      <View style={styles.headerRow}>
+        <TouchableOpacity
+          onPress={() =>
+            navigation.navigate('Main', {
+              screen: 'Settings',
+              animation: 'slide_from_left',
+            })
+          }
+          style={styles.iconButton}
+        >
+          <Ionicons name="arrow-back" size={24} color="#111" />
+        </TouchableOpacity>
+      </View>
       <View style={styles.content}>
         <Text style={styles.text}>Ayuda y Soporte</Text>
       </View>

--- a/apps/mobile/src/screens/HelpSupport/HelpSupportScreen.styles.js
+++ b/apps/mobile/src/screens/HelpSupport/HelpSupportScreen.styles.js
@@ -5,6 +5,16 @@ export default StyleSheet.create({
     flex: 1,
     backgroundColor: '#FFFFFF',
   },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingTop: 25,
+    paddingBottom: 12,
+    paddingHorizontal: 8,
+  },
+  iconButton: {
+    padding: 4,
+  },
   content: {
     flex: 1,
     justifyContent: 'center',

--- a/apps/mobile/src/screens/HelpSupport/HelpSupportScreen.styles.js
+++ b/apps/mobile/src/screens/HelpSupport/HelpSupportScreen.styles.js
@@ -1,0 +1,18 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  text: {
+    fontSize: 20,
+    color: '#111827',
+  },
+});

--- a/apps/mobile/src/screens/Notifications/NotificationsScreen.js
+++ b/apps/mobile/src/screens/Notifications/NotificationsScreen.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { View, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import styles from './HelpSupportScreen.styles';
+import styles from './NotificationsScreen.styles';
 
-export default function HelpSupportScreen() {
+export default function NotificationsScreen() {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.content}>
-        <Text style={styles.text}>Ayuda y Soporte</Text>
+        <Text style={styles.text}>Notificaciones</Text>
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/src/screens/Notifications/NotificationsScreen.js
+++ b/apps/mobile/src/screens/Notifications/NotificationsScreen.js
@@ -1,11 +1,28 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
 import styles from './NotificationsScreen.styles';
 
 export default function NotificationsScreen() {
+  const navigation = useNavigation();
+
   return (
     <SafeAreaView style={styles.container}>
+      <View style={styles.headerRow}>
+        <TouchableOpacity
+          onPress={() =>
+            navigation.navigate('Main', {
+              screen: 'Settings',
+              animation: 'slide_from_left',
+            })
+          }
+          style={styles.iconButton}
+        >
+          <Ionicons name="arrow-back" size={24} color="#111" />
+        </TouchableOpacity>
+      </View>
       <View style={styles.content}>
         <Text style={styles.text}>Notificaciones</Text>
       </View>

--- a/apps/mobile/src/screens/Notifications/NotificationsScreen.styles.js
+++ b/apps/mobile/src/screens/Notifications/NotificationsScreen.styles.js
@@ -5,6 +5,16 @@ export default StyleSheet.create({
     flex: 1,
     backgroundColor: '#FFFFFF',
   },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingTop: 25,
+    paddingBottom: 12,
+    paddingHorizontal: 8,
+  },
+  iconButton: {
+    padding: 4,
+  },
   content: {
     flex: 1,
     justifyContent: 'center',

--- a/apps/mobile/src/screens/Notifications/NotificationsScreen.styles.js
+++ b/apps/mobile/src/screens/Notifications/NotificationsScreen.styles.js
@@ -1,0 +1,18 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  text: {
+    fontSize: 20,
+    color: '#111827',
+  },
+});

--- a/apps/mobile/src/screens/Payment/PaymentScreen.js
+++ b/apps/mobile/src/screens/Payment/PaymentScreen.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { View, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import styles from './HelpSupportScreen.styles';
+import styles from './PaymentScreen.styles';
 
-export default function HelpSupportScreen() {
+export default function PaymentScreen() {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.content}>
-        <Text style={styles.text}>Ayuda y Soporte</Text>
+        <Text style={styles.text}>Métodos de Pago</Text>
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/src/screens/Payment/PaymentScreen.js
+++ b/apps/mobile/src/screens/Payment/PaymentScreen.js
@@ -1,11 +1,28 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
 import styles from './PaymentScreen.styles';
 
 export default function PaymentScreen() {
+  const navigation = useNavigation();
+
   return (
     <SafeAreaView style={styles.container}>
+      <View style={styles.headerRow}>
+        <TouchableOpacity
+          onPress={() =>
+            navigation.navigate('Main', {
+              screen: 'Settings',
+              animation: 'slide_from_left',
+            })
+          }
+          style={styles.iconButton}
+        >
+          <Ionicons name="arrow-back" size={24} color="#111" />
+        </TouchableOpacity>
+      </View>
       <View style={styles.content}>
         <Text style={styles.text}>Métodos de Pago</Text>
       </View>

--- a/apps/mobile/src/screens/Payment/PaymentScreen.styles.js
+++ b/apps/mobile/src/screens/Payment/PaymentScreen.styles.js
@@ -5,6 +5,16 @@ export default StyleSheet.create({
     flex: 1,
     backgroundColor: '#FFFFFF',
   },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingTop: 25,
+    paddingBottom: 12,
+    paddingHorizontal: 8,
+  },
+  iconButton: {
+    padding: 4,
+  },
   content: {
     flex: 1,
     justifyContent: 'center',

--- a/apps/mobile/src/screens/Payment/PaymentScreen.styles.js
+++ b/apps/mobile/src/screens/Payment/PaymentScreen.styles.js
@@ -1,0 +1,18 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  text: {
+    fontSize: 20,
+    color: '#111827',
+  },
+});

--- a/apps/mobile/src/screens/Settings/SettingsScreen.js
+++ b/apps/mobile/src/screens/Settings/SettingsScreen.js
@@ -1,10 +1,59 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, Pressable } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import styles from './SettingsScreen.styles';
 
 export default function SettingsScreen() {
+  const navigation = useNavigation();
+
+  const Option = ({ icon, label, onPress }) => (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.optionCard,
+        pressed && styles.optionCardPressed,
+      ]}
+    >
+      <View style={styles.iconWrapper}>
+        <Ionicons name={icon} size={24} color="#444" />
+      </View>
+      <Text style={styles.optionText}>{label}</Text>
+      <Ionicons name="chevron-forward" size={16} style={styles.arrow} />
+    </Pressable>
+  );
+
   return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#FFFFFF' }}>
-      <Text>Configuración</Text>
-    </View>
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.container}>
+        <View style={styles.statusBar}>
+          <Text style={styles.timeText}>9:41</Text>
+          <View style={styles.statusIcons}>
+            <Ionicons name="cellular" size={20} color="#000" style={styles.statusIcon} />
+            <Ionicons name="wifi" size={20} color="#000" style={styles.statusIcon} />
+            <Ionicons name="battery-full" size={20} color="#000" style={styles.statusIcon} />
+          </View>
+        </View>
+
+        <Text style={styles.header}>Configuración</Text>
+
+        <Option
+          icon="notifications-outline"
+          label="Notification"
+          onPress={() => navigation.navigate('Notifications')}
+        />
+        <Option
+          icon="card-outline"
+          label="Payment"
+          onPress={() => navigation.navigate('Payment')}
+        />
+        <Option
+          icon="help-circle-outline"
+          label="Help & Support"
+          onPress={() => navigation.navigate('HelpSupport')}
+        />
+      </View>
+    </SafeAreaView>
   );
 }

--- a/apps/mobile/src/screens/Settings/SettingsScreen.styles.js
+++ b/apps/mobile/src/screens/Settings/SettingsScreen.styles.js
@@ -1,0 +1,74 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  container: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingVertical: 20,
+  },
+  statusBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  timeText: {
+    fontSize: 16,
+    color: '#000',
+    fontWeight: '600',
+  },
+  statusIcons: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  statusIcon: {
+    marginLeft: 4,
+  },
+  header: {
+    fontSize: 24,
+    fontWeight: '600',
+    color: '#222222',
+    textAlign: 'center',
+    marginBottom: 32,
+  },
+  optionCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: 48,
+    backgroundColor: '#F7F7F7',
+    borderWidth: 1,
+    borderColor: '#E1E1E1',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.03,
+    shadowRadius: 1,
+    elevation: 1,
+  },
+  optionCardPressed: {
+    backgroundColor: '#EDEDED',
+  },
+  iconWrapper: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: '#EFEFEF',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  optionText: {
+    flex: 1,
+    marginLeft: 12,
+    fontSize: 16,
+    color: '#444444',
+  },
+  arrow: {
+    color: '#999999',
+  },
+});


### PR DESCRIPTION
## Summary
- build out Settings screen with status bar, options, and navigation
- add placeholder screens for Notifications, Payment and Help & Support
- include navigation routes for new screens

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6851b462bf488326b13fe6c14a77b0c7